### PR TITLE
update inventory system

### DIFF
--- a/Descension/Assets/Prefab/Items/Equippables/Arrows.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Arrows.prefab
@@ -43,8 +43,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9de04496ba64aa4ba11507d0bb2141e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controller: {fileID: 0}
   inventorySprite: {fileID: 21300000, guid: 2c2d6930501c33c44856e4ede5f1224e, type: 3}
-  quantity: 10
-  arrowPrefab: {fileID: 7911246415520734231, guid: 223d738c21d8c174da39104ad28d6bf0, type: 3}
-  bowReticleDistance: 2
+  maxQuantity: 20

--- a/Descension/Assets/Prefab/Items/Equippables/Bow.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Bow.prefab
@@ -43,8 +43,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f88bb05bc7d2bbc48b404cb885dc3534, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controller: {fileID: 0}
   inventorySprite: {fileID: 21300000, guid: 112553349fafbf447b64a1dd3e0ab81f, type: 3}
-  quantity: 1
+  maxQuantity: 1
   arrowPrefab: {fileID: 7911246415520734231, guid: 223d738c21d8c174da39104ad28d6bf0, type: 3}
   bowReticleDistance: 2

--- a/Descension/Assets/Prefab/Items/Equippables/Pick.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Pick.prefab
@@ -43,7 +43,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 45137cb7b1afe594b8aa035e4b719420, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controller: {fileID: 0}
   inventorySprite: {fileID: 21300000, guid: a1348ae01c274374f9934d25ba7bcac3, type: 3}
-  quantity: 20
+  maxQuantity: 20
   lootChance: 20

--- a/Descension/Assets/Prefab/Items/Equippables/Sword.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Sword.prefab
@@ -44,5 +44,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   inventorySprite: {fileID: 21300000, guid: 70224b364d3646742b61f3c8cfad4796, type: 3}
+  maxQuantity: 50
   damage: 10
   swordReticleDistance: 2

--- a/Descension/Assets/Prefab/UI/UserInterfaceCanvas.prefab
+++ b/Descension/Assets/Prefab/UI/UserInterfaceCanvas.prefab
@@ -709,7 +709,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 33.3
+  m_fontSize: 34
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -3239,6 +3239,7 @@ RectTransform:
   - {fileID: 4396195013810664760}
   - {fileID: 6748468115719812886}
   - {fileID: 6230814359985897303}
+  - {fileID: 4917790242165330504}
   m_Father: {fileID: 493105460297053246}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5823,7 +5824,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 33.3
+  m_fontSize: 34
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -8609,7 +8610,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 33.3
+  m_fontSize: 34
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -10768,6 +10769,108 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
   m_PrefabInstance: {fileID: 4593269451774422931}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5081043356743125219
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2426979709012859500}
+    m_Modifications:
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5539891978410845708, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+      propertyPath: m_Name
+      value: HotbarSlot4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+--- !u!224 &4917790242165330504 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 197311933046446763, guid: a8bf0cb38a98e5e478ab8ec8c516f7e2, type: 3}
+  m_PrefabInstance: {fileID: 5081043356743125219}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5844977388925548519
 PrefabInstance:

--- a/Descension/Assets/Scripts/Actor/Player/PlayerController.cs
+++ b/Descension/Assets/Scripts/Actor/Player/PlayerController.cs
@@ -128,10 +128,15 @@ namespace Actor.Player
 
         public void OnKilled()
         {
+            
+            InventoryManager.Instance.OnKilled();
+            
             if (_gameManager.IsPaused) return;
-
+            
             _gameManager.IsPaused = true;
             _uiManager.SwitchUi(UIType.Death);
+
+            
         }
 
         #endregion

--- a/Descension/Assets/Scripts/Items/ItemSpawner.cs
+++ b/Descension/Assets/Scripts/Items/ItemSpawner.cs
@@ -30,6 +30,9 @@ namespace Items
 
         public void DropItem(GameObject prefab, int quantity)
         {
+            // do not spawn if no quantity
+            if (quantity <= 0) return;
+            
             // spawn pickup
             SoundManager.Instance.ItemFound(); // TODO maybe replace with unique item drop sound
             GameObject pickupObject = Instantiate(prefab, GameManager.PlayerController.transform.position, Quaternion.identity);

--- a/Descension/Assets/Scripts/Items/Pickups/ArrowsItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/ArrowsItem.cs
@@ -1,4 +1,5 @@
 using System;
+using Managers;
 using UnityEngine;
 
 namespace Items.Pickups
@@ -6,9 +7,6 @@ namespace Items.Pickups
     public class ArrowsItem : EquippableItem
     {
         public static String Name = "Arrows";
-
-        public GameObject arrowPrefab;
-        public float bowReticleDistance = 2f;
         
         public override string GetName()
         {
@@ -16,9 +14,9 @@ namespace Items.Pickups
         }
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance()
+        public override Equippable CreateInstance(int slotIndex, int quantity)
         {
-            return new Arrows();
+            return new Arrows(slotIndex, quantity, maxQuantity, inventorySprite);
         }
     }
     
@@ -26,9 +24,14 @@ namespace Items.Pickups
     [Serializable]
     public class Arrows : Equippable
     {
-        public Arrows()
+        private PlayerControls _playerControls;
+        
+        public Arrows(int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
         {
             name = GetName();
+            
+            _playerControls = new PlayerControls();
+            _playerControls.Enable();
         }
 
         public override String GetName()
@@ -36,10 +39,20 @@ namespace Items.Pickups
             return ArrowsItem.Name;
         }
         
-        public override void OnDrop()
+        public override void SpawnDrop()
         {
-            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.arrowsPickupPrefab, quantity);
-            base.OnDrop();
+            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.arrowsPickupPrefab, Quantity);
         }
+        
+        public override void Update()
+        {
+            // if player tries to execute, equip bow if we have one
+            if (_playerControls.Default.Shoot.WasPressedThisFrame())
+            {
+                InventoryManager.Instance.EquipFirstSlottedItem(BowItem.Name, false);
+            }
+        }
+
+
     }
 }

--- a/Descension/Assets/Scripts/Items/Pickups/BowItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/BowItem.cs
@@ -21,9 +21,9 @@ namespace Items.Pickups
         }
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance()
+        public override Equippable CreateInstance(int slotIndex, int quantity)
         {
-            return new Bow(arrowPrefab, bowReticleDistance);
+            return new Bow(arrowPrefab, bowReticleDistance, slotIndex, quantity, maxQuantity, inventorySprite);
         }
     }
     
@@ -48,12 +48,13 @@ namespace Items.Pickups
             {
                 if (_arrows == null)
                 {
-                    _arrows = (Arrows) InventoryManager.Instance.slots.Find(slot => slot.GetName() == "Arrows");
+                    _arrows = (Arrows) InventoryManager.Instance.slots.Find(slot => slot.name == "Arrows");
                 }
                 return _arrows;
             }
+            set => _arrows = value;
         }
-        
+
         // gets the reticle object
         private Transform Reticle
         {
@@ -67,10 +68,9 @@ namespace Items.Pickups
             }
         }
         
-        public Bow(GameObject arrowPrefab, float bowReticleDistance)
+        public Bow(GameObject arrowPrefab, float bowReticleDistance, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
         {
             name = GetName();
-            
             _arrowPrefab = arrowPrefab;
             _bowReticleDistance = bowReticleDistance;
             _playerControls = new PlayerControls();
@@ -80,6 +80,11 @@ namespace Items.Pickups
         public String GetName()
         {
             return BowItem.Name;
+        }
+        
+        public override void SpawnDrop()
+        {
+            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.bowPickupPrefab, Quantity);
         }
 
         public override void OnEquip()
@@ -91,13 +96,7 @@ namespace Items.Pickups
         {
             Reticle.gameObject.SetActive(false);
         }
-
-        public override void OnDrop()
-        {
-            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.bowPickupPrefab, quantity);
-            base.OnDrop();
-        }
-
+        
         public override void Update()
         {
             _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
@@ -106,7 +105,6 @@ namespace Items.Pickups
         public override void FixedUpdate()
         {
             var screenPoint = GameManager.PlayerController.playerCamera.WorldToScreenPoint(GameManager.PlayerController.transform.localPosition);
-            // var screenPoint = _controller.playerCamera.WorldToScreenPoint(_transform.localPosition);
             var direction = (Input.mousePosition - screenPoint).normalized;
             
             // Set the position of the reticle on the screen according to input type
@@ -128,18 +126,11 @@ namespace Items.Pickups
             if (!_execute) return;
             _execute = false;
             
-            if (Arrows == null || Arrows.quantity <= 0)
+            if (Arrows == null)
             {
                 UIManager.Instance.GetHudController().ShowText("No arrows to shoot!");
                 return;
             }
-
-            if (Arrows.quantity <= 0)
-            {
-                Debug.Log("No arrows in quiver");
-                return;
-            }
-
 
             Vector3 playerPosition = GameManager.PlayerController.transform.position;
             
@@ -152,8 +143,8 @@ namespace Items.Pickups
             Arrow arrow = arrowObject.GetComponent<Arrow>();
             arrow.Initialize(direction);
             
-            // reduce quiver quantity
-            _arrows.SetQuantity(_arrows.quantity - 1);
+            // reduce arrows quantity
+            if (--Arrows.Quantity <= 0) Arrows = null;
         }
         
     }

--- a/Descension/Assets/Scripts/Items/Pickups/PickItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/PickItem.cs
@@ -20,9 +20,9 @@ namespace Items.Pickups
         }
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance()
+        public override Equippable CreateInstance(int slotIndex, int quantity)
         {
-            return new Pick(lootChance);
+            return new Pick(lootChance, slotIndex, quantity, maxQuantity, inventorySprite);
         }
     }
     
@@ -37,7 +37,7 @@ namespace Items.Pickups
         private PlayerControls _playerControls;
         
         
-        public Pick(float lootChance)
+        public Pick(float lootChance, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
         {
             this.name = GetName();
             _lootChance = lootChance;
@@ -50,11 +50,10 @@ namespace Items.Pickups
         {
             return PickItem.Name;
         }
-        
-        public override void OnDrop()
+
+        public override void SpawnDrop()
         {
-            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.pickPickupPrefab, quantity);
-            base.OnDrop();
+            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.pickPickupPrefab, Quantity);
         }
 
         public override void Update()
@@ -67,7 +66,7 @@ namespace Items.Pickups
             if (!_execute) return;
             _execute = false;
             
-            if (quantity <= 0)
+            if (Quantity <= 0)
             {
                 UIManager.Instance.GetHudController().ShowText("No picks!");
                 return;
@@ -100,8 +99,7 @@ namespace Items.Pickups
                 }
                 
                 Object.Destroy(rayCast.transform.gameObject);
-                
-                SetQuantity(quantity-1);
+                --Quantity;
             }
             else
             {

--- a/Descension/Assets/Scripts/Items/Pickups/Pickup.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/Pickup.cs
@@ -15,16 +15,16 @@ namespace Items.Pickups
         {
             if (Input.GetKeyDown(KeyCode.E) && _inRange)
             {
-                
-                if (!InventoryManager.Instance.PickupItem(item, quantity))
+                if (!InventoryManager.Instance.PickupItem(item, ref quantity))
                 {
-                    // SoundManager.Instance.ItemFound(); //TODO fail to pick up sound
+                    SoundManager.Instance.Error(); //TODO fail to pick up sound
                     UIManager.Instance.GetHudController().ShowText("Inventory full");
                     return;
                 }
                 SoundManager.Instance.ItemFound();
                 UIManager.Instance.GetHudController().ShowText(pickupMessage);
-                Destroy(gameObject);
+
+                if (quantity == 0) Destroy(gameObject);
             }
 
         }

--- a/Descension/Assets/Scripts/Items/Pickups/SwordItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/SwordItem.cs
@@ -21,9 +21,9 @@ namespace Items.Pickups
         }
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance()
+        public override Equippable CreateInstance(int slotIndex, int quantity)
         {
-            return new Sword(damage, swordReticleDistance);
+            return new Sword(damage, swordReticleDistance, slotIndex, quantity, maxQuantity, inventorySprite);
         }
     }
     
@@ -52,10 +52,10 @@ namespace Items.Pickups
             }
         }
         
-        public Sword(float swordDamage, float swordReticleDistance)
+        public Sword(float swordDamage, float swordReticleDistance, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
         {
             name = GetName();
-            
+
             _swordDamage = swordDamage;
             _swordReticleDistance = swordReticleDistance;
             
@@ -67,6 +67,11 @@ namespace Items.Pickups
         {
             return SwordItem.Name;
         }
+        
+        public override void SpawnDrop()
+        {
+            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.swordPickupPrefab, Quantity);
+        }
 
         public override void OnEquip()
         {
@@ -77,13 +82,7 @@ namespace Items.Pickups
         {
             Reticle.gameObject.SetActive(false);
         }
-
-        public override void OnDrop()
-        {
-            ItemSpawner.Instance.DropItem(ItemSpawner.Instance.swordPickupPrefab, quantity);
-            base.OnDrop();
-        }
-
+        
         public override void Update()
         {
             _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
@@ -104,7 +103,7 @@ namespace Items.Pickups
             if (!_execute) return;
             _execute = false;
             
-            if (quantity <= 0)
+            if (Quantity <= 0)
             {
                 UIManager.Instance.GetHudController().ShowText("Sword has no durability!");
                 return;
@@ -122,7 +121,7 @@ namespace Items.Pickups
                 enemyController.InflictDamage(_swordDamage);
             }
 
-            if (hitEnemies.Length >= 1) SetQuantity(quantity-1);
+            if (hitEnemies.Length >= 1) --Quantity;
         }
         
     }

--- a/Descension/Assets/Scripts/Managers/InventoryManager.cs
+++ b/Descension/Assets/Scripts/Managers/InventoryManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Items.Pickups;
@@ -19,10 +20,9 @@ namespace Managers
                 }
                 return _instance;
             }
-            set => _instance = value;
         }
         
-        public List<Equippable> slots = new List<Equippable>() { null, null, null };
+        public List<Equippable> slots = new List<Equippable>() { null, null, null, null };
         public int equippedSlot = -1;
         public int gold = 0;
 
@@ -36,15 +36,16 @@ namespace Managers
         void Update()
         {
             // check for equipped item slot change
-            if      (Input.GetKeyDown(KeyCode.Alpha1) && slots[0].quantity >= 0) EquipSlot(0);
-            else if (Input.GetKeyDown(KeyCode.Alpha2) && slots[1].quantity >= 0) EquipSlot(1);
-            else if (Input.GetKeyDown(KeyCode.Alpha3) && slots[2].quantity >= 0) EquipSlot(2);
+            if      (Input.GetKeyDown(KeyCode.Alpha1) && slots[0].Quantity >= 0) EquipSlot(0);
+            else if (Input.GetKeyDown(KeyCode.Alpha2) && slots[1].Quantity >= 0) EquipSlot(1);
+            else if (Input.GetKeyDown(KeyCode.Alpha3) && slots[2].Quantity >= 0) EquipSlot(2);
+            else if (Input.GetKeyDown(KeyCode.Alpha4) && slots[3].Quantity >= 0) EquipSlot(3);
 
             // run logic for equipped item
             if (equippedSlot != -1) slots[equippedSlot].Update();
             
             // drop equipped item on R
-            if (Input.GetKeyDown(KeyCode.R) && slots[0].quantity >= 0) DropSlot(equippedSlot);
+            if (Input.GetKeyDown(KeyCode.R)) DropSlot(equippedSlot);
         }
         
         void FixedUpdate()
@@ -52,70 +53,130 @@ namespace Managers
             // run logic for equipped weapon
             if (equippedSlot != -1) slots[equippedSlot].FixedUpdate();
         }
-
+        
+        // inventory logic for when player is killed
+        public void OnKilled()
+        {
+            ClearSlots();
+        }
+        
+        // sets item at index to equipped state
         void EquipSlot(int index)
         {
             if (equippedSlot != -1 && slots[equippedSlot] != null) slots[equippedSlot].OnUnEquip();
             equippedSlot = index;
             slots[equippedSlot].OnEquip();
             UIManager.Instance.Hotbar.SetActive(index);
+            Debug.Log("Slot " + index + " equipped");
         }
-
+        
+        // find first slot with equippable item and set it to equipped state
         void EquipFirstSlottedItem()
         {
             for (int i = 0; i < slots.Count; ++i)
             {
-                if (slots[i].quantity != -1)
+                if (slots[i].Quantity != -1)
                 {
                     EquipSlot(i);
-                    Debug.Log("Equipped " + i);
                     return;
                 }
             }
 
             equippedSlot = -1;
         }
+        
+        // find first slot with name and set it to equipped state, otherwise find first slot with equippable item and set it to equipped state if defaultAny=true
+        public void EquipFirstSlottedItem(string itemName, bool defaultAny = true)
+        {
+            for (int i = 0; i < slots.Count; ++i)
+            {
+                if (slots[i] != null && slots[i].name == itemName)
+                {
+                    EquipSlot(i);
+                    return;
+                }
+            }
 
-        void DropSlot(int index)
+            // equip first item if this fails
+            if (defaultAny) EquipFirstSlottedItem();
+        }
+        
+        // drop item at slot index and update UI
+        public void DropSlot(int index, bool autoEquip = true)
         {
             if (index != -1)
             {
+                var itemName = slots[index].name;
                 slots[index].OnDrop();
-                EquipFirstSlottedItem();
-                UIManager.Instance.Hotbar.DropItem(index);
+
+                // equip item with same name if possible if this was an executable item (not ammunition)
+                if (index == equippedSlot) EquipFirstSlottedItem(itemName);
             }
         }
-
-        public bool PickupItem(EquippableItem item, int quantity)
+        
+        // add item to inventory if room, quantity will be updated relative to how many items are remaining in the pickup if the inventory is full
+        // returns false if no item quantity/durability could be picked up
+        public bool PickupItem(EquippableItem item, ref int quantity)
         {
+            int initialQuantity = quantity;
+            
+            // keep code in case we dont want multiple slots of same item
+            // // add durability/quantity if already have this item
+            // var inventoryItem = slots.SingleOrDefault(x => x.name == item.GetName());
+            // if (inventoryItem != null && inventoryItem.Quantity < inventoryItem.GetMax())
+            // {
+            //     extra = quantity - (inventoryItem.GetMax() - inventoryItem.Quantity);
+            //     inventoryItem.Quantity += quantity;
+            //     if (extra == quantity)
+            //     {
+            //         Debug.Log("Pickup Failed, Item at Max");
+            //         return false;
+            //     }
+            //     Debug.Log("Pickup Success");
+            //     return true;
+            // }
+            
             // add durability/quantity if already have this item
-            var inventoryItem = slots.SingleOrDefault(x => x.name == item.GetName());
-            if (inventoryItem != null)
+            for (int i = 0; i < slots.Count && quantity > 0; ++i)
             {
-                inventoryItem.quantity += quantity;
-                Debug.Log("Pickup Success");
-                return true;
+                if (slots[i].name == item.GetName())
+                {
+                    var extra = quantity - (slots[i].GetMaxQuantity() - slots[i].Quantity);
+                    slots[i].Quantity += quantity;
+                    quantity = Math.Max(0, extra);
+                }
             }
 
-            // add to empty slot otherwise if one is available
-            for (int i = 0; i < slots.Count; ++i)
+            // add to empty slot if one is available
+            for (int i = 0; i < slots.Count && quantity > 0; ++i)
             {
                 if (slots[i].name.Length == 0)
                 {
-                    slots[i] = item.CreateInstance();
-                    slots[i].SetQuantity(quantity);
-                    slots[i].inventorySprite = item.inventorySprite;
-                    EquipSlot(i);
+                    slots[i] = item.CreateInstance(i, quantity);
+                    quantity -= slots[i].Quantity;
                     UIManager.Instance.Hotbar.PickupItem(slots[i], i);
-                    Debug.Log("Pickup Success");
-                    return true;
+                    
+                    if (equippedSlot == -1) EquipSlot(i); // auto equip if we have nothing equipped
                 }
             }
             
-            Debug.Log("Pickup Failed");
-
-            return false;
+            return quantity != initialQuantity;
         }
         
+        void ClearSlot(int slotIndex)
+        {
+            slots[slotIndex].Quantity = -1;
+        }
+        
+        // remove all items from slots and update UI
+        void ClearSlots()
+        {
+            for (int i = 0; i < slots.Count; ++i)
+            {
+                ClearSlot(i);
+            }
+        }
+        
+
     }
 }

--- a/Descension/Assets/Scripts/UI/Controllers/ButtonController/ShopItemButtonController.cs
+++ b/Descension/Assets/Scripts/UI/Controllers/ButtonController/ShopItemButtonController.cs
@@ -36,7 +36,8 @@ namespace UI.Controllers.ButtonController
                 return;
             }
 
-            if (!InventoryManager.Instance.PickupItem(item, 1))
+            int quantity = 1;
+            if (!InventoryManager.Instance.PickupItem(item, ref quantity))
             {
                 UIManager.Instance.GetShopUIController().DisplayFeedback("No room in inventory!");
                 SoundManager.Instance.Error();

--- a/Descension/Assets/Scripts/UI/MenuUI/Hotbar.cs
+++ b/Descension/Assets/Scripts/UI/MenuUI/Hotbar.cs
@@ -35,7 +35,7 @@ public class Hotbar : MonoBehaviour
     public void PickupItem(Equippable item, int slot)
     {
         _hotbarSlots[slot].SetSprite(item.inventorySprite);
-        _hotbarSlots[slot].SetQuantity(item.quantity);
+        _hotbarSlots[slot].SetQuantity(item.Quantity);
         _hotbarSlots[slot].SetOnQuantityUpdated(ref item.OnQuantityUpdated);
     }
 


### PR DESCRIPTION
- Increased inventory slots to 4.

- Adds max quantity/durability for each item.

- Slotted items are all cleared from inventory on death.

- Slotted items are removed from inventory when quantity/durability hits 0.

- Can have multiple of same item in different slots (if the quantity of an item is maxed, you can hold more of that item in another slot). This seems logical to me and adds more potential inventory management decisions (could have 2 slots filled with arrows, for example), but can be easily removed (only one slot for any given item) if we don't want this to be the behaviour.

- Pickups are only destroyed if entire quantity is picked up (can be partially left over if inventory could only pickup some of the available quantity).


