### PR TITLE
Add ItemCooldown

### DIFF
--- a/Descension/Assets/Prefab/Items/Equippables/Bow.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Bow.prefab
@@ -45,6 +45,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inventorySprite: {fileID: 21300000, guid: 112553349fafbf447b64a1dd3e0ab81f, type: 3}
   maxQuantity: 1
+  cooldownTime: 0.7
   Fact: 4
   arrowPrefab: {fileID: 7911246415520734231, guid: 223d738c21d8c174da39104ad28d6bf0, type: 3}
   damage: 10

--- a/Descension/Assets/Prefab/Items/Equippables/HealthPotion.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/HealthPotion.prefab
@@ -45,5 +45,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inventorySprite: {fileID: 21300000, guid: d41ef456d50fb9648983019f7b6d5af4, type: 3}
   maxQuantity: 5
+  cooldownTime: 0.5
   Fact: 7
   healAmount: 50

--- a/Descension/Assets/Prefab/Items/Equippables/Pick.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Pick.prefab
@@ -45,9 +45,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inventorySprite: {fileID: 21300000, guid: a1348ae01c274374f9934d25ba7bcac3, type: 3}
   maxQuantity: 30
+  cooldownTime: 0.3
   Fact: 1
   lootChance: 20
   reticleDistance: 7
   spriteOffset: 2
   spriteRotationOffset: 45
-  updateInterval: 3

--- a/Descension/Assets/Prefab/Items/Equippables/Sword.prefab
+++ b/Descension/Assets/Prefab/Items/Equippables/Sword.prefab
@@ -45,6 +45,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   inventorySprite: {fileID: 21300000, guid: 70224b364d3646742b61f3c8cfad4796, type: 3}
   maxQuantity: 50
+  cooldownTime: 0.5
   Fact: 3
   damage: 10
   spriteOffset: 2

--- a/Descension/Assets/Scripts/Items/Pickups/ArrowsItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/ArrowsItem.cs
@@ -12,40 +12,25 @@ namespace Items.Pickups
         public override string GetName() => Name;
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance(int slotIndex, int quantity) 
-            => new Arrows(slotIndex, quantity, maxQuantity, inventorySprite);
+        public override Equippable CreateInstance(int slotIndex, int quantity) => new Arrows(this, maxQuantity, quantity);
     }
     
     // logic for arrows (only used as ammo for bow)
     [Serializable]
-    public class Arrows : Equippable
+    internal class Arrows : Equippable
     {
-        private PlayerControls _playerControls;
+        public Arrows(ArrowsItem arrowsItem, int slotIndex, int quantity) : base(arrowsItem, slotIndex, quantity) => Init();
         
-        public Arrows(int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
-        {
-            name = GetName();
-            
-            _playerControls = new PlayerControls();
-            _playerControls.Enable();
-        }
+        public Arrows(Arrows arrows) : base(arrows) => Init();
         
-        public override Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite)
-            => new Arrows(slotIndex, quantity, maxQuantity, sprite);
+        private void Init() => name = ArrowsItem.Name;
 
-        public override String GetName() => ArrowsItem.Name;
+        public override Equippable DeepCopy() => new Arrows(this);
+
+        public override String GetName() => name;
 
         public override void SpawnDrop() => ItemSpawner.SpawnItem(ItemSpawner.ArrowsPrefab, PlayerPosition, Quantity);
-
-        public override void Update()
-        {
-            // if player tries to execute, equip bow if we have one
-            if (_playerControls.Default.Shoot.WasPressedThisFrame())
-            {
-                InventoryManager.EquipFirstSlottedItem(BowItem.Name, false);
-            }
-        }
-
-
+        
+        protected override void Execute() => InventoryManager.EquipFirstSlottedItem(BowItem.Name, false);
     }
 }

--- a/Descension/Assets/Scripts/Items/Pickups/EquippableItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/EquippableItem.cs
@@ -18,6 +18,9 @@ namespace Items.Pickups
         // the maximum quantity/durability for this item
         public int maxQuantity = 30;
 
+        // minimum time between executions
+        public float cooldownTime;
+        
         public abstract String GetName();
 
         public FactKey Fact;
@@ -30,33 +33,19 @@ namespace Items.Pickups
     [Serializable, CanBeNull]
     public class Equippable
     {
-        // do not use
-        public Equippable() { 
-            name = "";
-            _quantity = -1;
-            _slotIndex = -1;
-        }
-        public Equippable(int slotIndex, int quantity, int maxQuantity, Sprite sprite)
-        {
-            _slotIndex = slotIndex;
-            _maxQuantity = maxQuantity;
-            
-            Quantity = quantity;
-            inventorySprite = sprite;
-        }
-
-        public Equippable DeepCopy() => DeepCopy(_slotIndex, Quantity, _maxQuantity, inventorySprite);
-        
-        // must override
-        public virtual Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite) 
-            => new Equippable(slotIndex, quantity, maxQuantity, sprite);
-
+        // attributes
         public String name = "";
-        [HideInInspector] public Sprite inventorySprite;
         [SerializeField] private int _quantity;
         private int _maxQuantity;
         private int _slotIndex;
-
+        private float _cooldownTime;
+        [HideInInspector] public Sprite inventorySprite;
+        
+        // state
+        private float _cooldown;
+        private bool _execute;
+        private static PlayerControls _playerControls;
+        
         // quantity/durability for item
         public int Quantity
         {
@@ -83,6 +72,38 @@ namespace Items.Pickups
         
         public delegate void OnQuantityUpdatedDelegate(int newDurability);
         public OnQuantityUpdatedDelegate OnQuantityUpdated;
+        
+        // do not use
+        public Equippable() { 
+            name = "";
+            _quantity = -1;
+            _slotIndex = -1;
+        }
+
+        public Equippable(Equippable equippable) :
+            this(equippable._slotIndex, equippable._maxQuantity, equippable._quantity, equippable._cooldownTime, equippable.inventorySprite) {}
+
+        public Equippable(EquippableItem item, int slotIndex, int quantity) :
+            this(slotIndex, item.maxQuantity, quantity, item.cooldownTime, item.inventorySprite) {}
+
+        private Equippable(int slotIndex, int maxQuantity, int quantity, float cooldownTime, Sprite sprite)
+        {
+            _slotIndex = slotIndex;
+            _maxQuantity = maxQuantity;
+            
+            Quantity = quantity;
+            inventorySprite = sprite;
+
+            _cooldownTime = cooldownTime;
+
+            if (_playerControls == null)
+            {
+                _playerControls = new PlayerControls();
+                _playerControls.Enable();
+            }
+        }
+
+        public virtual Equippable DeepCopy() => new Equippable(this);
 
         // return name of equippable item
         public virtual String GetName() { return name; }
@@ -122,9 +143,24 @@ namespace Items.Pickups
         }
 
         // called like regular MonoBehavior Update() if this item is equipped
-        public virtual void Update() {}
+        public void Update() => _execute |= _playerControls.Default.Shoot.WasPressedThisFrame() && Time.time >= _cooldown;
 
         // called like regular MonoBehavior FixedUpdate() if this item is equipped
-        public virtual void FixedUpdate() { }
+        public void EquippedFixedUpdate()
+        {
+            FixedUpdate();
+            
+            if (!_execute) return;
+            
+            _execute = false;
+            _cooldown = Time.time + _cooldownTime;
+            Execute();
+        }
+        
+        // called like regular MonoBehavior FixedUpdate() if this item is equipped
+        protected virtual void FixedUpdate() {}
+        
+        // called when execute button is pressed and cooldown has finished if this item is equipped
+        protected virtual void Execute() {}
     }
 }

--- a/Descension/Assets/Scripts/Items/Pickups/ExplosivesItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/ExplosivesItem.cs
@@ -18,46 +18,42 @@ namespace Items.Pickups
         public override string GetName() => Name;
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance(int slotIndex, int quantity) 
-            => new Explosives(range, outOfRangeMessage, addToBombMessage, slotIndex, quantity, maxQuantity, inventorySprite);
+        public override Equippable CreateInstance(int slotIndex, int quantity) => new Explosives(this, slotIndex, quantity);
     }
     
     
     // logic for explosives
     [Serializable]
-    class Explosives : Equippable
+    internal class Explosives : Equippable
     {
+        // attributes
         private float _range;
         private string _outOfRangeMessage;
         private string _addToBombMessage;
-        private bool _execute;
-        private PlayerControls _playerControls;
-
-        public Explosives(float range, string outOfRangeMessage, string addToBombMessage, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
+        
+        public Explosives(ExplosivesItem explosivesItem, int slotIndex, int quantity) : base(explosivesItem, slotIndex, quantity) 
+            => Init(explosivesItem.range, explosivesItem.outOfRangeMessage, explosivesItem.addToBombMessage);
+        
+        public Explosives(Explosives explosives) : base(explosives) 
+            => Init(explosives._range, explosives._outOfRangeMessage, explosives._addToBombMessage);
+        
+        public void Init(float range, string outOfRangeMessage, string addToBombMessage)
         {
-            name = GetName();
+            name = ExplosivesItem.Name;
             _range = range;
             _outOfRangeMessage = outOfRangeMessage;
             _addToBombMessage = addToBombMessage;
-            _playerControls = new PlayerControls();
-            _playerControls.Enable();
         }
         
-        public override Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite) 
-            => new Explosives(_range, _outOfRangeMessage, _addToBombMessage, slotIndex, quantity, maxQuantity, sprite);
+        public override Equippable DeepCopy() => new Explosives(this);
 
-        public override String GetName() => ExplosivesItem.Name;
+        public override String GetName() => name;
 
         public override void SpawnDrop() => ItemSpawner.SpawnItem(ItemSpawner.ExplosivesPrefab, PlayerPosition, Quantity);
 
-        public override void Update() => _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
 
-        public override void FixedUpdate()
+        protected override void Execute()
         {
-            //******** Try to Execute if key pressed *******//
-            if (!_execute) return;
-            _execute = false;
-            
             if (BombScript.Instance)
             {
                 float distance = (BombScript.Instance.transform.position - PlayerController.Position).magnitude;
@@ -76,7 +72,6 @@ namespace Items.Pickups
                     DialogueManager.ShowNotification(_outOfRangeMessage);
                 }
             }
-            
         }
     }
 }

--- a/Descension/Assets/Scripts/Items/Pickups/HealthItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/HealthItem.cs
@@ -15,43 +15,36 @@ namespace Items.Pickups
         public override string GetName() => Name;
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance(int slotIndex, int quantity) 
-            => new HealthPotion(healAmount, slotIndex, quantity, maxQuantity, inventorySprite);
-        
+        public override Equippable CreateInstance(int slotIndex, int quantity) => new HealthPotion(this, slotIndex, quantity);
     }
 
     // logic for health potion
     [Serializable]
-    class HealthPotion : Equippable
+    internal class HealthPotion : Equippable
     {
-        private bool _execute;
-        private PlayerControls _playerControls;
+        // attributes
         private float _healAmount;
-
-        public HealthPotion(float healAmount, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
+        
+        public HealthPotion(HealthItem healthItem, int slotIndex, int quantity) : base(healthItem, slotIndex, quantity) 
+            => Init(healthItem.healAmount);
+        
+        public HealthPotion(HealthPotion healthPotion) : base(healthPotion) 
+            => Init(healthPotion._healAmount);
+        
+        public void Init(float healAmount)
         {
-            name = GetName();
+            name = HealthItem.Name;
             _healAmount = healAmount;
-
-            _playerControls = new PlayerControls();
-            _playerControls.Enable();
         }
         
-        public override Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite)
-            => new HealthPotion(_healAmount, slotIndex, quantity, maxQuantity, sprite);
+        public override Equippable DeepCopy() => new HealthPotion(this);
 
-        public override String GetName() => HealthItem.Name;
+        public override String GetName() => name;
 
         public override void SpawnDrop() => ItemSpawner.SpawnItem(ItemSpawner.HealthPrefab, PlayerPosition, Quantity);
 
-        public override void Update() => _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
-
-        public override void FixedUpdate()
+        protected override void Execute()
         {
-            //******** Try to Execute if key pressed *******//
-            if (!_execute) return;
-            _execute = false;
-
             if (Quantity <= 0)
             {
                 UIManager.GetHudController().ShowText("No Health Potions remaining!");

--- a/Descension/Assets/Scripts/Items/Pickups/PickItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/PickItem.cs
@@ -4,6 +4,7 @@ using Environment;
 using Managers;
 using UnityEngine;
 using Util.Enums;
+using Util.Helpers;
 using Object = UnityEngine.Object;
 using Random = UnityEngine.Random;
 
@@ -23,42 +24,45 @@ namespace Items.Pickups
         public override string GetName() => Name;
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance(int slotIndex, int quantity) 
-            => new Pick(lootChance, reticleDistance, spriteOffset, spriteRotationOffset, slotIndex, quantity, maxQuantity, inventorySprite);
+        public override Equippable CreateInstance(int slotIndex, int quantity) => new Pick(this, slotIndex, quantity);
     }
     
     
     
     // logic for pick item
     [Serializable]
-    class Pick : Equippable
+    internal class Pick : Equippable
     {
+        // attributes
         private float _lootChance;
         private float _reticleDistance;
         private float _spriteOffset;
         private float _spriteRotationOffset;
-        private bool _execute;
-        private int _swing;
-        private int _swingHit;
-        private bool _swinging;
-        private Vector3 _position;
-        private Vector3 _direction;
-        private PlayerControls _playerControls;
         
-        public Pick(float lootChance, float reticleDistance, float spriteOffset, float spriteRotationOffset, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
+        // state
+        private bool _swinging;
+        private int _swingAngle;
+        private int _swingHitAngle;
+        private float _aimAngle;
+        private Vector3 _aimDirection;
+        private Vector3 _playerPosition;
+
+        public Pick(PickItem pickItem, int slotIndex, int quantity) : base(pickItem, slotIndex, quantity) 
+            => Init(pickItem.lootChance, pickItem.reticleDistance, pickItem.spriteOffset, pickItem.spriteRotationOffset);
+        
+        public Pick(Pick pick) : base(pick) 
+            => Init(pick._lootChance, pick._reticleDistance, pick._spriteOffset, pick._spriteRotationOffset);
+        
+        public void Init(float lootChance, float reticleDistance, float spriteOffset, float spriteRotationOffset)
         {
             name = PickItem.Name;
             _lootChance = lootChance;
             _reticleDistance = reticleDistance;
             _spriteOffset = spriteOffset;
             _spriteRotationOffset = spriteRotationOffset;
-            
-            _playerControls = new PlayerControls();
-            _playerControls.Enable();
         }
         
-        public override Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite)
-            => new Pick(_lootChance, _reticleDistance, _spriteOffset, _spriteRotationOffset, slotIndex, quantity, maxQuantity, sprite);
+        public override Equippable DeepCopy() => new Pick(this);
 
         public override String GetName() => name;
         
@@ -82,39 +86,38 @@ namespace Items.Pickups
 
         public override void SpawnDrop() => ItemSpawner.SpawnItem(ItemSpawner.PickPrefab, PlayerPosition, Quantity);
 
-        public override void Update() => _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
-
-        public override void FixedUpdate()
+        protected override void FixedUpdate()
         {
             Vector3 screenPoint = PlayerController.Camera.WorldToScreenPoint(PlayerController.Instance.transform.localPosition);
-            _direction = (Input.mousePosition - screenPoint).normalized;
-            _position = PlayerPosition;
+            _aimDirection = (Input.mousePosition - screenPoint).normalized;
+            _playerPosition = PlayerPosition;
             
-            float angle = Mathf.Atan2(_direction.y, _direction.x) * Mathf.Rad2Deg;
-            Reticle.position = _position + (_direction * _reticleDistance);
-            SpriteTransform.SetPositionAndRotation(_position + _direction * _spriteOffset, new Quaternion { eulerAngles = new Vector3(0, 0, angle - _spriteRotationOffset + _swing) });
+            _aimAngle = _aimDirection.ToDegrees();
+            Reticle.position = _playerPosition + (_aimDirection * _reticleDistance);
+            SpriteTransform.SetPositionAndRotation(_playerPosition + _aimDirection * _spriteOffset, new Quaternion { eulerAngles = new Vector3(0, 0, _aimAngle - _spriteRotationOffset + _swingAngle) });
             
-            Debug.DrawLine(_position, Reticle.position);
+            Debug.DrawLine(_playerPosition, Reticle.position);
 
-            if (_swinging && _swing == _swingHit) CheckHit();
+            if (_swinging && _swingAngle == _swingHitAngle) CheckHit();
             
-            float absAngle = Math.Abs(angle);
-            if (absAngle >= 90 && _swing > -45) _swing -= 30; 
-            else if (absAngle < 90 && _swing < 45) _swing += 30; 
+            float absAngle = Math.Abs(_aimAngle);
+            if (absAngle >= 90 && _swingAngle > -45) _swingAngle -= 30; 
+            else if (absAngle < 90 && _swingAngle < 45) _swingAngle += 30;
+        }
 
-            if (!_execute) return;
-            _execute = false;
+        protected override void Execute()
+        {
             _swinging = true;
             
-            if (absAngle >= 90)
+            if (Math.Abs(_aimAngle) >= 90)
             {
-                _swing = 45;
-                _swingHit = 15;
+                _swingAngle = 45;
+                _swingHitAngle = 15;
             }
             else
             {
-                _swing = -45;
-                _swingHit = -15;
+                _swingAngle = -45;
+                _swingHitAngle = -15;
             }
 
             SoundManager.Swing();
@@ -124,7 +127,7 @@ namespace Items.Pickups
         {
             _swinging = false;
             
-            RaycastHit2D rayCast = Physics2D.Raycast(_position, _direction, _reticleDistance, (int) UnityLayer.Boulder);
+            RaycastHit2D rayCast = Physics2D.Raycast(_playerPosition, _aimDirection, _reticleDistance, (int) UnityLayer.Boulder);
             if (rayCast)
             {
                 SoundManager.RemoveRock();

--- a/Descension/Assets/Scripts/Items/Pickups/TimerItem.cs
+++ b/Descension/Assets/Scripts/Items/Pickups/TimerItem.cs
@@ -19,46 +19,41 @@ namespace Items.Pickups
         public override string GetName() => Name;
 
         // override just creates class instance, passes in editor set values
-        public override Equippable CreateInstance(int slotIndex, int quantity) 
-            => new Timer(range, outOfRangeMessage, addToBombMessage, slotIndex, quantity, maxQuantity, inventorySprite);
+        public override Equippable CreateInstance(int slotIndex, int quantity) => new Timer(this, slotIndex, quantity);
     }
     
     
-    // logic for explosives
+    // logic for timer
     [Serializable]
-    class Timer : Equippable
+    internal class Timer : Equippable
     {
+        // attributes
         private float _range;
         private string _outOfRangeMessage;
         private string _addToBombMessage;
-        private bool _execute;
-        private PlayerControls _playerControls;
-
-        public Timer(float range, string outOfRangeMessage, string addToBombMessage, int slotIndex, int quantity, int maxQuantity, Sprite sprite) : base(slotIndex, quantity, maxQuantity, sprite)
+        
+        public Timer(TimerItem timerItem, int slotIndex, int quantity) : base(timerItem, slotIndex, quantity) 
+            => Init(timerItem.range, timerItem.outOfRangeMessage, timerItem.addToBombMessage);
+        
+        public Timer(Timer timer) : base(timer) 
+            => Init(timer._range, timer._outOfRangeMessage, timer._addToBombMessage);
+        
+        public void Init(float range, string outOfRangeMessage, string addToBombMessage)
         {
-            name = GetName();
+            name = TimerItem.Name;
             _range = range;
             _outOfRangeMessage = outOfRangeMessage;
             _addToBombMessage = addToBombMessage;
-            _playerControls = new PlayerControls();
-            _playerControls.Enable();
         }
         
-        public override Equippable DeepCopy(int slotIndex, int quantity, int maxQuantity, Sprite sprite) 
-            => new Timer(_range, _outOfRangeMessage, _addToBombMessage, slotIndex, quantity, maxQuantity, sprite);
+        public override Equippable DeepCopy() => new Timer(this);
 
         public override String GetName() => TimerItem.Name;
 
         public override void SpawnDrop() => ItemSpawner.SpawnItem(ItemSpawner.TimerPrefab, PlayerPosition, Quantity);
-
-        public override void Update() => _execute |= _playerControls.Default.Shoot.WasPressedThisFrame();
-
-        public override void FixedUpdate()
+        
+        protected override void Execute()
         {
-            //******** Try to Execute if key pressed *******//
-            if (!_execute) return;
-            _execute = false;
-
             if (BombScript.Instance)
             {
                 float distance = (BombScript.Instance.transform.position - PlayerController.Position).magnitude;

--- a/Descension/Assets/Scripts/Managers/InventoryManager.cs
+++ b/Descension/Assets/Scripts/Managers/InventoryManager.cs
@@ -82,7 +82,7 @@ namespace Managers
             if (GameManager.IsFrozen || ++_updateCount % updateInterval != 0) return;
             
             // run logic for equipped weapon
-            if (equippedSlot != -1) slots[equippedSlot].FixedUpdate();
+            if (equippedSlot != -1) slots[equippedSlot].EquippedFixedUpdate();
         }
         
         // inventory logic for when player is killed


### PR DESCRIPTION
- Added cooldown parameter for EquippableItem so we can easily adjust or add a cooldown to other items.
- Set sword cooldown to 0.5 second.
- Set bow cooldown to 0.7 seconds.
- Set pick cooldown to 0.3 seconds.
- Set health cooldown to 0.5 seconds.
- Refactored EquippableItem class to improve construction, copying, and execution.
- Made EquippableItem.Update() non-virtual so player input is handled in parent for items.